### PR TITLE
fix issue 13: compiler warnings in sse2 only path for unused params

### DIFF
--- a/src/c/shabal_sse2.c
+++ b/src/c/shabal_sse2.c
@@ -27,11 +27,8 @@ void init_shabal_sse2() {
 
 void init_shabal_avx2() {}
 void init_shabal_avx() {}
-
-void find_best_deadline_avx(char* scoops, uint64_t nonce_count, char* gensig,
-                            uint64_t* best_deadline, uint64_t* best_offset) {}
-void find_best_deadline_avx2(char* scoops, uint64_t nonce_count, char* gensig,
-                             uint64_t* best_deadline, uint64_t* best_offset) {}
+void find_best_deadline_avx() {}
+void find_best_deadline_avx2() {}
 
 void find_best_deadline_sse2(char* scoops, uint64_t nonce_count, char* gensig,
                              uint64_t* best_deadline, uint64_t* best_offset) {


### PR DESCRIPTION
removed unused params getting flagged by compiler.