### PR TITLE
fix travis to use a proper EXT4 environment instead of devicemapper on XFS

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,6 @@
+sudo: required
+dist: trusty
+
 language: rust
 rust:
   - stable


### PR DESCRIPTION
XFS is weird.
According to this, https://docs.travis-ci.com/user/reference/overview/#virtualisation-environment-vs-operating-system
we're getting an devicemapped XFS filesystem which must be returning nothing from 'df' and causes get_sector_size failure.

Changing travis to use an EXT4 image corrects this. 