### PR TITLE
fix #22: add explicit -O2 to prevent Illegal Instruction on xeon

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -28,5 +28,6 @@ fn main() {
         config.file("src/c/shabal_sse2.c");
     }
 
+    config.flag("-O2"); // -O3 fails on xeon and maybe others
     config.compile("libshabal.a");
 }


### PR DESCRIPTION
This adds explicit -O2 to prevent Illegal Instruction failure known to occur on xeon per issue #22.
Without testing all possible architectures, is seems reasonable to just add the flag and anyone wanting O3 can change it locally.

thanks.
