### PR TITLE
Add Dockerfile for automated builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,11 @@
+FROM liuchong/rustup:nightly-musl as builder
+WORKDIR /app
+COPY . .
+RUN cargo build --release --features=simd
+
+FROM alpine:latest
+RUN apk update && apk upgrade && apk add --no-cache bash util-linux
+WORKDIR /app
+COPY --from=builder /app/target/x86_64-unknown-linux-musl/release/scavenger .
+ENTRYPOINT ["./scavenger"]
+CMD ["--config","/data/config.yaml"]


### PR DESCRIPTION
This PR adds a Dockerfile which can be used for automated builds. It currently builds a statically linked binary for cpu-only (simd) using musl and copies it into a plain alpine image with util-linux installed so `df` and `lsblk` are available and `scavenger` can start.

To enable automatic builds one needs to setup a docker hub account and automated build once. The following link goes into depth on how to achieve this: https://docs.docker.com/docker-hub/builds/

The following repo is an example repo to demonstrate how this might look once done: https://hub.docker.com/r/felixbrucker/scavenger-autobuild-example

The official repo might be named like the one in git: `PoC-Consortium/scavenger`

Related to #40 