### PR TITLE
Add info about using the official docker image

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,33 @@ The miner needs a **config.yaml** file with the following structure:
 
 https://github.com/PoC-Consortium/scavenger/blob/master/config.yaml
 
+### Docker
+
+A docker image based on alpine linux is built automatically on every commit to master: `spebern/scavenger`
+This image will use only your cpu.
+
+To run it on the fly use something like this:
+```
+docker run \
+--rm \
+--name scavenger \
+--volume /path/to/your/config.yaml:/data/config.yaml \
+--volume /path/to/your/disks:/disks \
+spebern/scavenger
+```
+
+Alternatively a docker compose file could look like this:
+```
+version: '2'
+services:
+  scavenger:
+    image: spebern/scavenger
+    restart: always
+    volumes:
+      - /path/to/your/disks:/disks
+      - /path/to/your/config.yaml:/data/config.yaml
+```
+
 ### Donate 
 * bold: BURST-8V9Y-58B4-RVWP-8HQAV
   - architecture


### PR DESCRIPTION
This PR adds some info regarding the docker image usage to the README.

Related to #41 