### PR TITLE
NEON for aarch64 always enabled

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -17,7 +17,7 @@ fn main() {
     #[cfg(not(target_env = "msvc"))]
     shared_config.flag("-std=c99");
 
-    #[cfg(all(not(target_env = "msvc"), not(target_arch = "aarch64")))]
+    #[cfg(not(target_env = "msvc"))]
     shared_config.flag("-mtune=native");
 
     let mut config = shared_config.clone();
@@ -32,7 +32,7 @@ fn main() {
              fn build(shared_config: cc::Build){
                 let mut config = shared_config.clone();
 
-                #[cfg(not(target_env = "msvc"))]
+                #[cfg(all(not(target_env = "msvc"), not(target_arch = "aarch64")))]
                 config.flag("-mfpu=neon");
 
                 config

--- a/src/main.rs
+++ b/src/main.rs
@@ -91,7 +91,7 @@ cfg_if! {
             #[cfg(target_arch = "arm")]
             let neon = is_arm_feature_detected!("neon");
             #[cfg(target_arch = "aarch64")]
-            let neon = is_aarch64_feature_detected!("neon");
+            let neon = true;
 
             if neon {
                 info!("SIMD extensions: NEON");

--- a/src/worker.rs
+++ b/src/worker.rs
@@ -155,7 +155,7 @@ pub fn create_worker_task(
                             #[cfg(target_arch = "arm")]
                             let neon = is_arm_feature_detected!("neon");
                             #[cfg(target_arch = "aarch64")]
-                            let neon = is_aarch64_feature_detected!("neon");
+                            let neon = true;
                             if neon {
                                 find_best_deadline_neon(
                                     bs.as_ptr() as *mut c_void,
@@ -249,7 +249,7 @@ pub fn create_worker_task(
                         #[cfg(target_arch = "arm")]
                         let neon = is_arm_feature_detected!("neon");
                         #[cfg(target_arch = "aarch64")]
-                        let neon = is_aarch64_feature_detected!("neon");
+                        let neon = true;
                         if neon {
                             find_best_deadline_neon(
                                 bs.as_ptr() as *mut c_void,


### PR DESCRIPTION
https://stackoverflow.com/questions/29851128/gcc-arm64-aarch64-unrecognized-command-line-option-mfpu-neon/29891469#29891469

```
lscpu 
Architecture:        aarch64
Byte Order:          Little Endian
CPU(s):              6
On-line CPU(s) list: 0-5
Thread(s) per core:  1
Core(s) per socket:  3
Socket(s):           2
Vendor ID:           ARM
Model:               4
Model name:          Cortex-A53
Stepping:            r0p4
CPU max MHz:         1800.0000
CPU min MHz:         408.0000
BogoMIPS:            48.00
Flags:               fp asimd evtstrm aes pmull sha1 sha2 crc32

```

I tested on RK3399, Pine64 RockPro64