### PR TITLE
Use 4096 sector size as default when diskutil can not get drive info.

### DIFF
--- a/src/utils.rs
+++ b/src/utils.rs
@@ -66,7 +66,8 @@ cfg_if! {
                 }
             }
             if sector_size == 0 {
-                panic!("Abort: Unable to determine disk physical sector size from diskutil info")
+                sector_size = 4096;
+                warn!("Abort: Unable to determine disk physical sector size from diskutil info. Using default 4096")
             }
             sector_size
         }


### PR DESCRIPTION
On macos diskutil can not be used on network drives and therefore sector_size is 0. Instead of quitting with panic, warn and use 4096 as default.